### PR TITLE
Have InMemoryTracker log.debug metrics for easy debugging.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,19 +3,23 @@
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="lib/default/aws-java-sdk.jar"/>
-	<classpathentry kind="lib" path="lib/default/commons-codec.jar"/>
-	<classpathentry kind="lib" path="lib/default/commons-lang.jar"/>
-	<classpathentry kind="lib" path="lib/default/commons-logging.jar"/>
-	<classpathentry kind="lib" path="lib/default/guava.jar"/>
-	<classpathentry kind="lib" path="lib/default/httpclient.jar"/>
-	<classpathentry kind="lib" path="lib/default/httpcore.jar"/>
-	<classpathentry kind="lib" path="lib/default/jackson-core-asl.jar"/>
-	<classpathentry kind="lib" path="lib/default/mail.jar"/>
-	<classpathentry kind="lib" path="lib/default/stax-api.jar"/>
-	<classpathentry kind="lib" path="lib/default/stax.jar"/>
-	<classpathentry kind="lib" path="lib/test/concurrent-test-utils.jar"/>
-	<classpathentry kind="lib" path="lib/test/junit.jar"/>
-	<classpathentry kind="lib" path="lib/test/mockito-all.jar"/>
+	<classpathentry kind="lib" path="lib/default/aws-java-sdk-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/commons-codec-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/commons-lang-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/commons-logging-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/guava-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/httpclient-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/httpcore-jar.jar"/>
+	<classpathentry kind="lib" path="lib/test/concurrent-test-utils-jar.jar"/>
+	<classpathentry kind="lib" path="lib/test/junit-jar.jar"/>
+	<classpathentry kind="lib" path="lib/test/mockito-all-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/slf4j-api-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/jackson-annotations-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/jackson-core-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/jackson-databind-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/joda-time-jar.jar"/>
+	<classpathentry kind="lib" path="lib/default/jsr305-jar.jar"/>
+	<classpathentry kind="lib" path="lib/test/slf4j-api-jar.jar"/>
+	<classpathentry kind="lib" path="lib/test/slf4j-jdk14-jar.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/ivy.xml
+++ b/ivy.xml
@@ -20,21 +20,17 @@
 
   <dependencies defaultconfmapping="sources->sources();%->default" defaultconf="default;sources">
     <!-- default (compile, test, runtime) dependencies -->
-    <dependency org="amazon" name="aws-java-sdk" rev="1.3.15" />
-    <dependency org="apache" name="commons-lang" rev="2.6" />
-    <dependency org="google" name="guava" rev="12.0.1" />
-
-    <!-- build time only dependencies -->
-    <dependency org="findbugs" name="findbugs" rev="1.3.9" conf="buildtime" />
-    <dependency org="checkstyle" name="checkstyle" rev="all-5.1" conf="buildtime" />
-    <dependency org="svntask" name="svntask" rev="1.0.7" conf="buildtime" />
-    <dependency org="cobertura" name="cobertura" rev="1.9.4.1" conf="buildtime" />
+    <dependency org="com.amazonaws" name="aws-java-sdk" rev="1.7.5" />
+    <dependency org="commons-lang" name="commons-lang" rev="2.6" />
+    <dependency org="com.google.guava" name="guava" rev="12.0.1" />
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" />
 
     <!-- test time only dependencies -->
     <dependency org="junit" name="junit" rev="4.8.2" conf="test" />
     <dependency org="bizo.com" name="concurrent-test-utils" rev="1.1-dev-20110613233842" conf="test" />
-    <dependency org="mockito" name="mockito" rev="1.8.5" conf="test" />
+    <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test" />
+    <dependency org="org.slf4j" name="slf4j-jdk14" rev="1.7.5" conf="test" />
 
-    <exclude org="google" module="google-collect" />
+    <exclude org="com.google.code.google-collections" module="google-collect" />
   </dependencies>
 </ivy-module>

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,8 @@
+
+# for use at test time
+handlers=java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level=FINEST
+
+.level=FINEST
+

--- a/src/main/java/com/bizo/asperatus/tracker/impl/buffer/InMemoryTracker.java
+++ b/src/main/java/com/bizo/asperatus/tracker/impl/buffer/InMemoryTracker.java
@@ -5,6 +5,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.bizo.asperatus.model.CompoundDimension;
 import com.bizo.asperatus.model.Unit;
 import com.bizo.asperatus.tracker.AbstractMetricTracker;
@@ -18,8 +21,15 @@ public final class InMemoryTracker extends AbstractMetricTracker implements Metr
   private final AtomicReference<Map<MetricKey, MetricStatistics>> stats =
     new AtomicReference<Map<MetricKey, MetricStatistics>>(new HashMap<MetricKey, MetricStatistics>());
 
+  private static final Logger log = LoggerFactory.getLogger(InMemoryTracker.class);
+
   @Override
-  public synchronized void track(final String metricName, final Number value, final Unit unit, final Collection<CompoundDimension> dimensions) {
+  public synchronized void track(
+      final String metricName,
+      final Number value,
+      final Unit unit,
+      final Collection<CompoundDimension> dimensions) {
+    log.debug("Logging " + metricName + " = " + value + " " + unit);
     for (final CompoundDimension d : dimensions) {
       getOrCreateStats(new MetricKey(metricName, d), unit).add(value);
     }

--- a/src/test/java/com/bizo/asperatus/tracker/impl/AbstractCloudwatch.java
+++ b/src/test/java/com/bizo/asperatus/tracker/impl/AbstractCloudwatch.java
@@ -4,70 +4,56 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ResponseMetadata;
+import com.amazonaws.regions.Region;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest;
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmHistoryRequest;
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmHistoryResult;
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsForMetricRequest;
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsForMetricResult;
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest;
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
-import com.amazonaws.services.cloudwatch.model.DisableAlarmActionsRequest;
-import com.amazonaws.services.cloudwatch.model.EnableAlarmActionsRequest;
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest;
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult;
-import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
-import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
-import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest;
-import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.SetAlarmStateRequest;
+import com.amazonaws.services.cloudwatch.model.*;
 
 /**
  * Throws UnsupportedOperationException for everything.
  */
 public class AbstractCloudwatch implements AmazonCloudWatch {
   @Override
-  public void setEndpoint(String endpoint) throws IllegalArgumentException {
+  public void setEndpoint(final String endpoint) throws IllegalArgumentException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void putMetricAlarm(PutMetricAlarmRequest putMetricAlarmRequest)
+  public void putMetricAlarm(final PutMetricAlarmRequest putMetricAlarmRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void putMetricData(PutMetricDataRequest putMetricDataRequest)
+  public void putMetricData(final PutMetricDataRequest putMetricDataRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public ListMetricsResult listMetrics(ListMetricsRequest listMetricsRequest)
+  public ListMetricsResult listMetrics(final ListMetricsRequest listMetricsRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public GetMetricStatisticsResult getMetricStatistics(GetMetricStatisticsRequest getMetricStatisticsRequest)
+  public GetMetricStatisticsResult getMetricStatistics(final GetMetricStatisticsRequest getMetricStatisticsRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void disableAlarmActions(DisableAlarmActionsRequest disableAlarmActionsRequest)
+  public void disableAlarmActions(final DisableAlarmActionsRequest disableAlarmActionsRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public DescribeAlarmsResult describeAlarms(DescribeAlarmsRequest describeAlarmsRequest)
+  public DescribeAlarmsResult describeAlarms(final DescribeAlarmsRequest describeAlarmsRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
@@ -75,35 +61,35 @@ public class AbstractCloudwatch implements AmazonCloudWatch {
 
   @Override
   public DescribeAlarmsForMetricResult describeAlarmsForMetric(
-      DescribeAlarmsForMetricRequest describeAlarmsForMetricRequest)
+      final DescribeAlarmsForMetricRequest describeAlarmsForMetricRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public DescribeAlarmHistoryResult describeAlarmHistory(DescribeAlarmHistoryRequest describeAlarmHistoryRequest)
+  public DescribeAlarmHistoryResult describeAlarmHistory(final DescribeAlarmHistoryRequest describeAlarmHistoryRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void enableAlarmActions(EnableAlarmActionsRequest enableAlarmActionsRequest)
+  public void enableAlarmActions(final EnableAlarmActionsRequest enableAlarmActionsRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void deleteAlarms(DeleteAlarmsRequest deleteAlarmsRequest)
+  public void deleteAlarms(final DeleteAlarmsRequest deleteAlarmsRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void setAlarmState(SetAlarmStateRequest setAlarmStateRequest)
+  public void setAlarmState(final SetAlarmStateRequest setAlarmStateRequest)
       throws AmazonServiceException,
       AmazonClientException {
     throw new UnsupportedOperationException();
@@ -130,7 +116,11 @@ public class AbstractCloudwatch implements AmazonCloudWatch {
   }
 
   @Override
-  public ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest request) {
+  public ResponseMetadata getCachedResponseMetadata(final AmazonWebServiceRequest request) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setRegion(final Region arg0) throws IllegalArgumentException {
   }
 }

--- a/src/test/java/com/bizo/asperatus/tracker/impl/InMemoryTrackerTest.java
+++ b/src/test/java/com/bizo/asperatus/tracker/impl/InMemoryTrackerTest.java
@@ -16,25 +16,30 @@ import com.google.common.collect.Lists;
 
 public final class InMemoryTrackerTest {
 
+  static {
+    System.setProperty("java.util.logging.config.file", "./logging.properties");
+  }
+
   private final InMemoryTracker tracker = new InMemoryTracker();
 
   @Test
   public void test() {
-    List<CompoundDimension> dims = Lists.newArrayList(new CompoundDimension(new Dimension("d1", "x"), new Dimension("d2", "z")));
+    final List<CompoundDimension> dims =
+      Lists.newArrayList(new CompoundDimension(new Dimension("d1", "x"), new Dimension("d2", "z")));
 
     tracker.track("a", 1, Unit.Count, dims);
     tracker.track("a", 2, Unit.Count, dims);
-    
+
     dims.clear();
     dims.add(new CompoundDimension(new Dimension("d1", "x"), new Dimension("d1", "v"), new Dimension("d3", "z")));
-    
+
     tracker.track("a", 1, Unit.Count, dims);
     tracker.track("a", 2, Unit.Count, dims);
     tracker.track("b", 1, Unit.Seconds, dims);
     tracker.track("b", 7, Unit.Seconds, dims);
 
     final Map<MetricKey, MetricStatistics> data = tracker.reset();
-    
+
     assertEquals(3, data.size());
 
     // verify it's clear
@@ -42,10 +47,10 @@ public final class InMemoryTrackerTest {
 
     // check records
     assertStats(data, "a", "d1=x,d2=z", Unit.Count, 2, 3, 1, 2);
-    assertStats(data, "a", "d1=x,d1=v,d3=z", Unit.Count, 2, 3, 1, 2);    
+    assertStats(data, "a", "d1=x,d1=v,d3=z", Unit.Count, 2, 3, 1, 2);
     assertStats(data, "b", "d1=x,d1=v,d3=z", Unit.Seconds, 2, 8, 1, 7);
   }
-  
+
   private void assertStats(
       final Map<MetricKey, MetricStatistics> data,
       final String name,
@@ -64,16 +69,16 @@ public final class InMemoryTrackerTest {
     assertEquals(max, stats.getMax(), 0.0000001f);
     assertEquals(unit, stats.getUnit());
   }
-  
+
   private CompoundDimension toDims(final String s) {
     final List<Dimension> ret = new ArrayList<Dimension>();
-    
+
     final String[] dims = s.split(",");
     for (final String d : dims) {
       final String[] p = d.split("=");
       ret.add(new Dimension(p[0], p[1]));
     }
-    
+
     return new CompoundDimension(ret);
   }
 }


### PR DESCRIPTION
I've seen literally 3 separate developers in the last 2 weeks add a "log to CW + also log.debug" helper methods.

But then, in one case, we ended up taking the log.debugs out, as it was too chatty in production.

Seems like InMemoryMetricTracker always logging would be a good balance of "useful for development but no affect on production".
